### PR TITLE
Add RULES. One ruleset for all channels.

### DIFF
--- a/resources/RULES.md
+++ b/resources/RULES.md
@@ -1,0 +1,7 @@
+# JupiterBroadcasting Matrix Chat Rules
+
+1. Wheaton's Law: Don't be a dick.
+
+2. No unsolicited spam or direct messages.
+
+3. Stay on `/topic`.


### PR DESCRIPTION
Why put rules here instead of directly in a room's /topic?

- Rule changes can be made in PRs to this repo
- The same rules can be referenced from all channels

Although, if the new website's build infrastructure is made public, then they might be better there:

- These rules aren't necessarily specific to Matrix, they could apply to Telegram, Discord, and IRC.
- The rules could be consumed by the static site generator and made into a nice  jupiterbroadcasting.com/chat#rules